### PR TITLE
always remove tmp dir using trap

### DIFF
--- a/quandary/grading/grade.sh
+++ b/quandary/grading/grade.sh
@@ -53,6 +53,10 @@ SUBMISSION_TGZ=$1
 export TMPDIR=.
 SUBMISSION_DIR=`mktemp -d`
 
+# Remove tmp directory
+INITIAL_DIR=`pwd`
+trap "cd $INITIAL_DIR && rm -rf $SUBMISSION_DIR" EXIT
+
 if ! [ -x "$(command -v realpath)" ]; then
   echo 'Command realpath is not installed. Trying something else, but $2 and $4 need to be relative paths for it to work!'
   REF_IMPL="../$2"
@@ -93,9 +97,5 @@ do
   #echo do_one_test $line
   do_one_test $line
 done < $TESTCASES_FILE
-
-# Remove tmp directory
-cd ..
-rm -r $SUBMISSION_DIR
 
 echo Total score: $SCORE out of $MAX_SCORE


### PR DESCRIPTION
Previously, when the grading script failed (including when it is cancelled via CTRL + C), the tmp directory would not be removed.

This PR uses `trap` so that no matter when or how the script exits, the tmp directory will always be deleted.