### PR TITLE
remove test case that tests undefined behavior

### DIFF
--- a/quandary/grading/simplified-testing.dat
+++ b/quandary/grading/simplified-testing.dat
@@ -1,7 +1,7 @@
 1 funcList.q        10
 1 params.q          -2
 1 params.q          12
-1 params2.q         93 
+1 params2.q         93
 1 ident.q           1
 1 ident2.q          5
 1 assignStmt.q      73
@@ -76,7 +76,6 @@
 1 randomNum.q       10000
 1 randomNum.q       1
 1 randomNum.q       -10
-1 randomNum.q       0
 1 badassign.q       23
 1 badassign2.q      34
 1 badassign3.q      923


### PR DESCRIPTION
`quandary.pdf` specifies that `randomInt` returns an int in [0, n). When `n == 0`, the reference interpreter crashes due to a divide by zero error (I imagine it uses `% n` (where n is the argument passed to randomInt) to restrict the range of random numbers).

My implementation of `randomInt` does not crash when `n == 0` (it returns 0), so this test case fails.

I believe this means one of the following:

1. There is a bug in the reference interpreter.
    In this case, the reference implementation of `randomInt` should be changed such that `randomInt(0)` returns 0, and this PR should be closed.
2. The test case that this PR deletes is testing undefined behavior.
    In this case, this PR should be approved.